### PR TITLE
feat: Enable JSON logging via environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer-lake"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/circulating-supply/src/main.rs
+++ b/circulating-supply/src/main.rs
@@ -24,9 +24,14 @@ const CIRCULATING_SUPPLY: &str = "circulating_supply";
 async fn main() {
     dotenv::dotenv().ok();
 
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
+
+    if std::env::var("ENABLE_JSON_LOGS").is_ok() {
+        subscriber.json().init()
+    } else {
+        subscriber.compact().init()
+    }
 
     let pool = models::establish_connection(
         &std::env::var("DATABASE_URL")

--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1
+
+* Add capability to output logs in JSON format
+
 ## 0.11.0
 
 * `indexer-explorer-lake` now uses the default AWS credentials provider. Credentials can no longer be set via command line arguments and environment variables need to be updated as follows:

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer-lake"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.62.1"

--- a/indexer/src/configs.rs
+++ b/indexer/src/configs.rs
@@ -140,10 +140,15 @@ pub(crate) fn init_tracing(debug: bool) -> anyhow::Result<()> {
         }
     }
 
-    tracing_subscriber::fmt::Subscriber::builder()
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(env_filter)
-        .with_writer(std::io::stderr)
-        .init();
+        .with_writer(std::io::stderr);
+
+    if std::env::var("ENABLE_JSON_LOGS").is_ok() {
+        subscriber.json().init();
+    } else {
+        subscriber.compact().init();
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Adds support for logging in JSON format for both `circulating-supply` and `indexer-explorer-lake`. Compact logs (what we currently have) are not parsed very well by log aggergators (Grafana/GCP Cloud Logs) which is why JSON logs are necessary.

By default, the compact format will be used, to enable JSON logs the `ENABLE_JSON_LOGS` environment variable must be set. I made this configurable so we can have readable logs in local development, and JSON logs in production.