### PR TITLE
refactor: Use default AWS SDK credentials provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ You need to provide credentials via `.env` file for:
   ```
 - AWS S3 (permission to read from buckets):
   ```bash
-  $ echo "LAKE_AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE" >> .env
-  $ echo "LAKE_AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  $ echo "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE" >> .env
+  $ echo "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" >> .env
   ```
 
 Then you need to apply migrations to create necessary database structure. For this you'll need `diesel-cli`, you can install it like so:

--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.11.0
+
+* `indexer-explorer-lake` now uses the default AWS credentials provider. Credentials can no longer be set via command line arguments and environment variables need to be updated as follows:
+```diff
+- "LAKE_AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE"
+- "LAKE_AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
++ "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
++ "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+```
+
 ## 0.10.3
 
 * Extract database logic to library crate


### PR DESCRIPTION
This PR removes the custom AWS credentials provider, replacing it with the default. This changes the following:
1. AWS credentials can no longer be supplied via command line arguments
2. Credential names now match the default provided by AWS

This allows us to play nicely with existing AWS tooling allowing credentials to be sourced from `~/.aws/credentials` or credentials managers like [aws-vault](https://github.com/99designs/aws-vault).

⚠️ The AWS credential environment variables will need to be updated before rolling out this change to testnet/mainnet