### PR TITLE
feat: Expose block metrics from Indexer over http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer-lake"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,10 +1875,12 @@ dependencies = [
  "explorer-database",
  "futures",
  "itertools",
+ "lazy_static",
  "near-jsonrpc-client",
  "near-lake-framework",
  "near-sdk",
  "openssl-probe",
+ "prometheus",
  "r2d2",
  "tokio",
  "tokio-stream",
@@ -2794,6 +2796,27 @@ checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-diesel"
 version = "0.3.1-alpha.0"
 source = "git+https://github.com/frol/actix-diesel?rev=3a001986c89dfabfc3c448d8bae28525101b4992#3a001986c89dfabfc3c448d8bae28525101b4992"
@@ -47,6 +64,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-http"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "ahash 0.7.6",
+ "base64 0.13.0",
+ "bitflags",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "sha1",
+ "smallvec",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
 name = "actix-macros"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +108,19 @@ checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+dependencies = [
+ "bytestring",
+ "http",
+ "regex",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -68,6 +135,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-server"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "num_cpus",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash 0.7.6",
+ "bytes",
+ "bytestring",
+ "cfg-if 1.0.0",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time 0.3.9",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "actix_derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +235,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
@@ -102,6 +266,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -704,6 +883,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,9 +929,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bytes-utils"
@@ -748,6 +948,15 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "bytestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f83e57d9154148e355404702e2694463241880b939570d7c97c014da7a69a1"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "c2-chacha"
@@ -797,6 +1006,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -898,6 +1110,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+dependencies = [
+ "percent-encoding",
+ "time 0.3.9",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1275,6 +1498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1863,7 @@ version = "0.11.1"
 dependencies = [
  "actix",
  "actix-rt",
+ "actix-web",
  "anyhow",
  "aws-sdk-s3",
  "aws-types",
@@ -1694,6 +1928,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1968,24 @@ name = "libc"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+
+[[package]]
+name = "local-channel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -1780,6 +2047,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -2392,6 +2668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +3158,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,9 +3411,17 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
+ "itoa",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -3670,4 +3971,33 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.2
+
+* Expose prometheus metrics via HTTP server
+
 ## 0.11.1
 
 * Add capability to output logs in JSON format

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer-lake"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.62.1"

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.62.1"
 [dependencies]
 actix = "0.13.0"
 actix-rt = "2.2.0"
+actix-web = "=4.0.1"
 anyhow = "1.0.51"
 aws-types = "0.13.0"
 aws-sdk-s3 = "0.13.0"

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -19,9 +19,11 @@ clap = { version = "3.1.6", features = ["color", "derive", "env"] }
 dotenv = "0.15.0"
 futures = "0.3.5"
 itertools = "0.10.3"
+lazy_static = "^1.4"
 # syn version conflict, replace with crates.io version once released
 near-sdk = { git = "https://github.com/near/near-sdk-rs", rev="03487c184d37b0382dd9bd41c57466acad58fc1f" }
 openssl-probe = { version = "0.1.2" }
+prometheus = "0.13.0"
 r2d2 = "0.8.8"
 tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -11,6 +11,7 @@ use explorer_database::{adapters, models, receipts_cache};
 use crate::configs::Opts;
 
 mod configs;
+mod metrics;
 
 // Categories for logging
 const INDEXER_FOR_EXPLORER: &str = "indexer_for_explorer";
@@ -177,6 +178,8 @@ async fn main() -> anyhow::Result<()> {
 
         while let Some(_handle_message) = handlers.next().await {}
     });
+
+    metrics::init_server().await?;
 
     match sender.await {
         Ok(Ok(())) => Ok(()),

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -154,7 +154,7 @@ async fn main() -> anyhow::Result<()> {
         std::sync::Arc::new(Mutex::new(SizedCache::with_size(100_000)));
 
     let config: near_lake_framework::LakeConfig = opts.to_lake_config().await;
-    let (sender, stream) = near_lake_framework::streamer(config);
+    let (_, stream) = near_lake_framework::streamer(config);
 
     tokio::spawn(async move {
         tracing::info!(
@@ -181,9 +181,5 @@ async fn main() -> anyhow::Result<()> {
 
     metrics::init_server().await?;
 
-    match sender.await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => Err(e),
-        Err(e) => Err(anyhow::Error::from(e)), // JoinError
-    }
+    Ok(())
 }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -23,7 +23,7 @@ async fn handle_message(
     receipts_cache: receipts_cache::ReceiptsCache,
 ) -> anyhow::Result<()> {
     metrics::BLOCK_COUNT.inc();
-    metrics::BLOCK_HEIGHT.set(streamer_message.block.header.height.try_into().unwrap());
+    metrics::LATEST_BLOCK_HEIGHT.set(streamer_message.block.header.height.try_into().unwrap());
 
     debug!(
         target: INDEXER_FOR_EXPLORER,

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -22,6 +22,9 @@ async fn handle_message(
     strict_mode: bool,
     receipts_cache: receipts_cache::ReceiptsCache,
 ) -> anyhow::Result<()> {
+    metrics::BLOCK_COUNT.inc();
+    metrics::BLOCK_HEIGHT.set(streamer_message.block.header.height.try_into().unwrap());
+
     debug!(
         target: INDEXER_FOR_EXPLORER,
         "ReceiptsCache #{} \n {:#?}", streamer_message.block.header.height, &receipts_cache

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -46,10 +46,10 @@ async fn get_metrics() -> impl Responder {
 }
 
 pub(crate) async fn init_server() -> Result<(), std::io::Error> {
-    let port: u16 = std::env::var("HTTP_PORT")
+    let port: u16 = std::env::var("PORT")
         .unwrap_or_else(|_| String::from("3030"))
         .parse()
-        .expect("Unable to parse `HTTP_PORT`");
+        .expect("Unable to parse `PORT`");
 
     info!(
         target: crate::INDEXER_FOR_EXPLORER,

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -1,5 +1,49 @@
-use actix_web::{web, App, HttpServer};
+use actix_web::{get, App, HttpServer, Responder};
+use lazy_static::lazy_static;
+use prometheus::{Encoder, IntCounter, IntGauge, Opts};
 use tracing::info;
+
+lazy_static! {
+    pub(crate) static ref BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+        "indexer_explorer_lake_block_height",
+        "Last processed block height"
+    )
+    .unwrap();
+    pub(crate) static ref BLOCK_COUNT: IntCounter = try_create_int_counter(
+        "indexer_explorer_lake_block_count",
+        "Number of indexed blocks"
+    )
+    .unwrap();
+}
+
+fn try_create_int_gauge(name: &str, help: &str) -> prometheus::Result<IntGauge> {
+    let opts = Opts::new(name, help);
+    let gauge = IntGauge::with_opts(opts)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+fn try_create_int_counter(name: &str, help: &str) -> prometheus::Result<IntCounter> {
+    let opts = Opts::new(name, help);
+    let counter = IntCounter::with_opts(opts)?;
+    prometheus::register(Box::new(counter.clone()))?;
+    Ok(counter)
+}
+
+#[get("/metrics")]
+async fn get_metrics() -> impl Responder {
+    let mut buffer = Vec::<u8>::new();
+    let encoder = prometheus::TextEncoder::new();
+    loop {
+        match encoder.encode(&prometheus::gather(), &mut buffer) {
+            Ok(_) => break,
+            Err(err) => {
+                eprintln!("{:?}", err);
+            }
+        }
+    }
+    String::from_utf8(buffer.clone()).unwrap()
+}
 
 pub(crate) async fn init_server() -> Result<(), std::io::Error> {
     let port: u16 = std::env::var("HTTP_PORT")
@@ -12,7 +56,7 @@ pub(crate) async fn init_server() -> Result<(), std::io::Error> {
         "Starting metrics server on http://0.0.0.0:{port}"
     );
 
-    HttpServer::new(|| App::new().service(web::resource("/")))
+    HttpServer::new(|| App::new().service(get_metrics))
         .bind(("0.0.0.0", port))?
         .run()
         .await

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -1,0 +1,19 @@
+use actix_web::{web, App, HttpServer};
+use tracing::info;
+
+pub(crate) async fn init_server() -> Result<(), std::io::Error> {
+    let port: u16 = std::env::var("HTTP_PORT")
+        .unwrap_or_else(|_| String::from("3030"))
+        .parse()
+        .expect("Unable to parse `HTTP_PORT`");
+
+    info!(
+        target: crate::INDEXER_FOR_EXPLORER,
+        "Starting metrics server on http://0.0.0.0:{port}"
+    );
+
+    HttpServer::new(|| App::new().service(web::resource("/")))
+        .bind(("0.0.0.0", port))?
+        .run()
+        .await
+}

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -4,9 +4,9 @@ use prometheus::{Encoder, IntCounter, IntGauge, Opts};
 use tracing::info;
 
 lazy_static! {
-    pub(crate) static ref BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
-        "indexer_explorer_lake_block_height",
-        "Last processed block height"
+    pub(crate) static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+        "indexer_explorer_lake_latest_block_height",
+        "Height of last processed block"
     )
     .unwrap();
     pub(crate) static ref BLOCK_COUNT: IntCounter = try_create_int_counter(


### PR DESCRIPTION
This PR stands up an HTTP server within `indexer-explorer-lake` and exposes the following metrics on `:3030/metrics`:
1. Block height - height of the last processed block
2. Block count - total blocks processed since starting

I've intentionally not included block rate/BPS as we can achieve this with PromQL `rate()` function to calculate the rate at which the block count is increasing. This saves us from implementing the time based logic ourselves.
