### PR TITLE
chore: Add missing Changelog/Cargo version entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer-lake"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "circulating_supply"
+name = "circulating-supply"
 version = "0.1.0"
 dependencies = [
  "actix",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer-lake"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "actix",
  "actix-rt",

--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.3
+
+* Extract database logic to library crate
+
 ## 0.10.2
 
 * Avoid recreating access key on transfer to implicit account

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer-lake"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.62.1"

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer-lake"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.62.1"


### PR DESCRIPTION
In some of my previous PRs I forgot to update both `CHANGELOG.md` and `Cargo.toml > version`. I'm adding these missed changes here so that when releasing to production we aren't running the same version with different code.