### PR TITLE
feat: Add non-blocking logging support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "near-sdk",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uint 0.8.5",
 ]
@@ -1649,6 +1650,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uint 0.8.5",
 ]
@@ -3250,6 +3252,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/circulating-supply/Cargo.toml
+++ b/circulating-supply/Cargo.toml
@@ -16,6 +16,7 @@ dotenv = "0.15.0"
 near-sdk = { git = "https://github.com/near/near-sdk-rs", rev="03487c184d37b0382dd9bd41c57466acad58fc1f" }
 tokio = { version = "1.1", features = ["sync", "time"] }
 tracing = "0.1.13"
+tracing-appender = "0.1.2"
 tracing-subscriber = "0.2.4"
 uint = { version = "0.8.3", default-features = false }
 

--- a/circulating-supply/src/main.rs
+++ b/circulating-supply/src/main.rs
@@ -24,7 +24,10 @@ const CIRCULATING_SUPPLY: &str = "circulating_supply";
 async fn main() {
     dotenv::dotenv().ok();
 
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+
     let subscriber = tracing_subscriber::fmt()
+        .with_writer(non_blocking)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
 
     if std::env::var("ENABLE_JSON_LOGS").is_ok() {

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -25,6 +25,7 @@ r2d2 = "0.8.8"
 tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
+tracing-appender = "0.1.2"
 tracing-subscriber = "0.2.4"
 uint = { version = "0.8.3", default-features = false }
 

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -136,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
 
     let opts: Opts = Opts::parse();
 
-    configs::init_tracing(opts.debug)?;
+    let _worker_guard = configs::init_tracing(opts.debug)?;
 
     // We establish connection as early as possible as an additional sanity check.
     // Indexer should fail if .env file with credentials is missing/wrong


### PR DESCRIPTION
This PR adds non-blocking logging support for both `indexer` and `circulating-supply` via the  [tracing_appender](https://docs.rs/tracing-appender/0.2.2/tracing_appender/index.html) library.