### PR TITLE
refactor: Metrics server config/errors

### DIFF
--- a/indexer/src/configs.rs
+++ b/indexer/src/configs.rs
@@ -31,6 +31,9 @@ pub(crate) struct Opts {
     /// Sets the concurrency for indexing. Note: concurrency (set to 2+) may lead to warnings due to tight constraints between transactions and receipts (those will get resolved eventually, but unless it is the second pass of indexing, concurrency won't help at the moment).
     #[clap(long, default_value = "1")]
     pub concurrency: std::num::NonZeroU16,
+    /// Port to enable metrics/health service
+    #[clap(long, short, env, default_value_t = 3030)]
+    pub port: u16,
     /// Chain ID: testnet or mainnet
     #[clap(subcommand)]
     pub chain_id: ChainId,

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -182,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
         while let Some(_handle_message) = handlers.next().await {}
     });
 
-    metrics::init_server().await?;
+    metrics::init_server(opts.port).await?;
 
     Ok(())
 }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -182,7 +182,5 @@ async fn main() -> anyhow::Result<()> {
         while let Some(_handle_message) = handlers.next().await {}
     });
 
-    metrics::init_server(opts.port).await?;
-
-    Ok(())
+    metrics::init_server(opts.port).await
 }

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -45,12 +45,7 @@ async fn get_metrics() -> impl Responder {
     String::from_utf8(buffer.clone()).unwrap()
 }
 
-pub(crate) async fn init_server() -> Result<(), std::io::Error> {
-    let port: u16 = std::env::var("PORT")
-        .unwrap_or_else(|_| String::from("3030"))
-        .parse()
-        .expect("Unable to parse `PORT`");
-
+pub(crate) async fn init_server(port: u16) -> Result<(), std::io::Error> {
     info!(
         target: crate::INDEXER_FOR_EXPLORER,
         "Starting metrics server on http://0.0.0.0:{port}"

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -45,7 +45,7 @@ async fn get_metrics() -> impl Responder {
     String::from_utf8(buffer.clone()).unwrap()
 }
 
-pub(crate) async fn init_server(port: u16) -> Result<(), std::io::Error> {
+pub(crate) async fn init_server(port: u16) -> anyhow::Result<()> {
     info!(
         target: crate::INDEXER_FOR_EXPLORER,
         "Starting metrics server on http://0.0.0.0:{port}"
@@ -55,4 +55,5 @@ pub(crate) async fn init_server(port: u16) -> Result<(), std::io::Error> {
         .bind(("0.0.0.0", port))?
         .run()
         .await
+        .map_err(|e| anyhow::anyhow!("Error starting metrics server: {}", e))
 }


### PR DESCRIPTION
This PR does two things:
1. Adds `--port` as CLI argument so it can be passed from both CLI and environment
2. Removes unreachable `Ok(())` from `main()` to reduce the confusion around `metrics::init_server()`
